### PR TITLE
Add support for Go

### DIFF
--- a/Portroach/SiteHandler.pm
+++ b/Portroach/SiteHandler.pm
@@ -39,6 +39,7 @@ use Portroach::SiteHandler::Pecl;
 use Portroach::SiteHandler::PyPI;
 use Portroach::SiteHandler::RubyGems;
 use Portroach::SiteHandler::SourceForge;
+use Portroach::SiteHandler::Go;
 
 use strict;
 

--- a/Portroach/SiteHandler.pm
+++ b/Portroach/SiteHandler.pm
@@ -30,6 +30,7 @@ package Portroach::SiteHandler;
 use Portroach::SiteHandler::Bitbucket;
 use Portroach::SiteHandler::CPAN;
 use Portroach::SiteHandler::GitHub;
+use Portroach::SiteHandler::Go;
 use Portroach::SiteHandler::Hackage;
 use Portroach::SiteHandler::Launchpad;
 use Portroach::SiteHandler::Mozilla;
@@ -39,7 +40,6 @@ use Portroach::SiteHandler::Pecl;
 use Portroach::SiteHandler::PyPI;
 use Portroach::SiteHandler::RubyGems;
 use Portroach::SiteHandler::SourceForge;
-use Portroach::SiteHandler::Go;
 
 use strict;
 

--- a/Portroach/SiteHandler/Go.pm
+++ b/Portroach/SiteHandler/Go.pm
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (C) 2014, Jasper Lievisse Adriaanse <jasper@openbsd.org>
+# Copyright (C) 2021, Aaron Bieber <abieber@openbsd.org>
 #
 # Permission to use, copy, modify, and distribute this software for any
 # purpose with or without fee is hereby granted, provided that the above

--- a/Portroach/SiteHandler/Go.pm
+++ b/Portroach/SiteHandler/Go.pm
@@ -73,7 +73,7 @@ sub CanHandle
 
 	my ($url) = @_;
 
-	return ($url =~ /proxy\.golang\.org//);
+	return ($url =~ /proxy\.golang\.org/);
 }
 
 
@@ -94,16 +94,8 @@ sub GetFiles
 
 	my ($url, $port, $files) = @_;
 
-	carp Dumper $url;
-	carp Dumper $port;
-
-	my ($registry, $package, $resp, $query, $ua);
+	my ($registry, $resp, $query, $ua);
 	$registry = 'https://proxy.golang.org/';
-
-	# Strip all the digits at the end to keep the stem of the module.
-	if ($port->{distname} =~ /(.*?)-(\d+)/) {
-	    $package = $1;
-	}
 
 	$query = $url;
 	$query =~ s/v\//latest/;
@@ -120,7 +112,7 @@ sub GetFiles
 	    $version = $json->{Version};
 	    next unless $version;
 
-	    push(@$files, "$package/-/$package-$version.tgz");
+	    push(@$files, "$port->{name}-${version}.zip");
 	} else {
 	    _debug("GET failed: " . $resp->code);
 	    return 0;

--- a/Portroach/SiteHandler/Go.pm
+++ b/Portroach/SiteHandler/Go.pm
@@ -94,11 +94,15 @@ sub GetFiles
 
 	my ($url, $port, $files) = @_;
 
-	my ($registry, $resp, $query, $ua);
+	my ($registry, $dist, $resp, $query, $ua);
 	$registry = 'https://proxy.golang.org/';
 
+	if ($port->{distname} =~ /^(.*)-(v)?\d+\.\d+.\d+(.*)?$/) {
+	    $dist = $1;
+	}
+
 	$query = $url;
-	$query =~ s/v\//latest/;
+	$query =~ s/\@v\//\@latest/;
 
 	_debug("GET $query");
 	$ua = LWP::UserAgent->new;
@@ -112,7 +116,10 @@ sub GetFiles
 	    $version = $json->{Version};
 	    next unless $version;
 
-	    push(@$files, "$port->{name}-${version}.zip");
+	    $port->{newver} = $version;
+	    $version =~ s/v//;
+
+	    push(@$files, "$dist-${version}.zip");
 	} else {
 	    _debug("GET failed: " . $resp->code);
 	    return 0;

--- a/Portroach/SiteHandler/Go.pm
+++ b/Portroach/SiteHandler/Go.pm
@@ -1,0 +1,151 @@
+#------------------------------------------------------------------------------
+# Copyright (C) 2014, Jasper Lievisse Adriaanse <jasper@openbsd.org>
+#
+# Permission to use, copy, modify, and distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+#------------------------------------------------------------------------------
+
+package Portroach::SiteHandler::Go;
+
+use JSON qw(decode_json);
+use LWP::UserAgent;
+
+use Portroach::Const;
+use Portroach::Config;
+
+use strict;
+
+require 5.006;
+
+
+#------------------------------------------------------------------------------
+# Globals
+#------------------------------------------------------------------------------
+
+push @Portroach::SiteHandler::sitehandlers, __PACKAGE__;
+
+our %settings;
+
+
+#------------------------------------------------------------------------------
+# Func: new()
+# Desc: Constructor.
+#
+# Args: n/a
+#
+# Retn: $self
+#------------------------------------------------------------------------------
+
+sub new
+{
+	my $self      = {};
+	my $class     = shift;
+
+	$self->{name} = 'Go';
+
+	bless ($self, $class);
+	return $self;
+}
+
+
+#------------------------------------------------------------------------------
+# Func: CanHandle()
+# Desc: Ask if this handler (package) can handle the given site.
+#
+# Args: $url - URL of site.
+#
+# Retn: $res - true/false.
+#------------------------------------------------------------------------------
+
+sub CanHandle
+{
+	my $self = shift;
+
+	my ($url) = @_;
+
+	return ($url =~ /proxy\.golang\.org//);
+}
+
+
+#------------------------------------------------------------------------------
+# Func: GetFiles()
+# Desc: Extract a list of files from the given URL. Simply query the API.
+#
+# Args: $url     - URL we would normally fetch from.
+#       \%port   - Port hash fetched from database.
+#       \@files  - Array to put files into.
+#
+# Retn: $success - False if file list could not be constructed; else, true.
+#------------------------------------------------------------------------------
+
+sub GetFiles
+{
+	my $self = shift;
+
+	my ($url, $port, $files) = @_;
+
+	carp Dumper $url;
+	carp Dumper $port;
+
+	my ($registry, $package, $resp, $query, $ua);
+	$registry = 'https://proxy.golang.org/';
+
+	# Strip all the digits at the end to keep the stem of the module.
+	if ($port->{distname} =~ /(.*?)-(\d+)/) {
+	    $package = $1;
+	}
+
+	$query = $url;
+	$query =~ s/v\//latest/;
+
+	_debug("GET $query");
+	$ua = LWP::UserAgent->new;
+	$ua->agent(USER_AGENT);
+	$resp = $ua->request(HTTP::Request->new(GET => $query));
+
+	if ($resp->is_success) {
+	    my ($json, $version);
+
+    	    $json = decode_json($resp->decoded_content);
+	    $version = $json->{Version};
+	    next unless $version;
+
+	    push(@$files, "$package/-/$package-$version.tgz");
+	} else {
+	    _debug("GET failed: " . $resp->code);
+	    return 0;
+	}
+
+	return 1;
+}
+
+
+#------------------------------------------------------------------------------
+# Func: _debug()
+# Desc: Print a debug message.
+#
+# Args: $msg - Message.
+#
+# Retn: n/a
+#------------------------------------------------------------------------------
+
+sub _debug
+{
+	my ($msg) = @_;
+
+	$msg = '' if (!$msg);
+
+	print STDERR "(" . __PACKAGE__ . ") $msg\n" if ($settings{debug});
+}
+
+1;

--- a/portroach.pl
+++ b/portroach.pl
@@ -875,7 +875,7 @@ sub FindNewestFile
 
 	foreach my $file (@$files)
 	{
-		my ($poss_path, $github);
+		my ($poss_path, $github, $golang);
 
 		if ($file =~ /^(.*)\/(.*?)$/) {
 			# Files from SiteHandlers can come with paths
@@ -887,8 +887,12 @@ sub FindNewestFile
 			$poss_path = '';
 		}
 
+		$golang = 1 if ($port->{mastersites} =~ /proxy\.golang\.org/);
+
 		foreach my $distfile (split ' ', $port->{distfiles})
 		{
+			# in Go we explicitly know what the next version is if we have it.
+			next if ($golang);
 			my $v = $port->{ver};
 			my $s = $port->{sufx};
 			my $old_v;
@@ -1089,6 +1093,13 @@ sub FindNewestFile
 		$new_found  = undef;
 		$poss_match = undef;
 		$poss_url   = undef;
+	}
+
+	# In Go we set newver explicitly, so check it here.
+	if (defined $port->{newver} && defined $port->{ver} && vercompare($port->{newver}, $port->{ver})) {
+		$new_found = $port->{newver};
+		$old_found = $port->{ver};
+		$poss_match = $port->{newver};
 	}
 
 	return {

--- a/portroach.pl
+++ b/portroach.pl
@@ -871,11 +871,11 @@ sub FindNewestFile
 {
 	my ($port, $site, $files) = @_;
 
-	my ($poss_match, $poss_url, $old_found, $new_found);
+	my ($poss_match, $poss_url, $old_found, $new_found, $golang);
 
 	foreach my $file (@$files)
 	{
-		my ($poss_path, $github, $golang);
+		my ($poss_path, $github);
 
 		if ($file =~ /^(.*)\/(.*?)$/) {
 			# Files from SiteHandlers can come with paths
@@ -1096,10 +1096,12 @@ sub FindNewestFile
 	}
 
 	# In Go we set newver explicitly, so check it here.
-	if (defined $port->{newver} && defined $port->{ver} && vercompare($port->{newver}, $port->{ver})) {
-		$new_found = $port->{newver};
-		$old_found = $port->{ver};
-		$poss_match = $port->{newver};
+	if ($golang) {
+		if (defined $port->{newver} && defined $port->{ver} && vercompare($port->{newver}, $port->{ver})) {
+			$new_found = $port->{newver};
+			$old_found = $port->{ver};
+			$poss_match = $port->{newver};
+		}
 	}
 
 	return {


### PR DESCRIPTION
I am not sure if my approach is too hackish, I am basically setting `$port->{newver}` in the `GetFiles` sub of `Portroach::SiteHandler::Go`. Then I added a Go specific check in `FindNewestFile`.

```
qbit@tal[0]:~/src/portroach git:(go)$ perl -I. ./portroach.pl showupdates 
portroach v2.0.11, by Shaun Amott and Jasper Lievisse Adriaanse

SQLite is currently only supported in non-forking mode!
--> Forcing num_children => 0...

aaron bieber <abieber@openbsd.org>'s ports:
  audio/navidrome v0.42.1 -> v0.44.1
  net/go-ipfs v0.8.0 -> v0.9.0
  security/rbw 1.1.2 -> 1.3.0
qbit@tal[0]:~/src/portroach git:(go)$ 
```

With this diff I can see updates for `audio/navidrome` and `net/go-ipfs`.
